### PR TITLE
Add context-aware `Once`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Added
+
+- Add `Once`, a context-aware and "failable" variant of `sync.Once`
+
 ## [0.1.0] - 2020-05-20
 
 - Initial release

--- a/once.go
+++ b/once.go
@@ -1,0 +1,47 @@
+package cosyne
+
+import (
+	"context"
+	"sync/atomic"
+)
+
+// Once is a context-aware and "failable" version of sync.Once.
+type Once struct {
+	done uint32 // atomic bool
+	m    Mutex
+}
+
+// Do calls the function fn if and only if Do() has never been called
+// successfully for this instance of Once.
+//
+// A successful call is one that returns a nil error and does not panic.
+func (o *Once) Do(
+	ctx context.Context,
+	fn func(context.Context) error,
+) error {
+	if atomic.LoadUint32(&o.done) == 0 {
+		return o.doSlow(ctx, fn)
+	}
+
+	return nil
+}
+
+func (o *Once) doSlow(
+	ctx context.Context,
+	fn func(context.Context) error,
+) error {
+	if err := o.m.Lock(ctx); err != nil {
+		return err
+	}
+	defer o.m.Unlock()
+
+	if o.done == 0 {
+		if err := fn(ctx); err != nil {
+			return err
+		}
+
+		atomic.StoreUint32(&o.done, 1)
+	}
+
+	return nil
+}

--- a/once_test.go
+++ b/once_test.go
@@ -1,0 +1,80 @@
+package cosyne_test
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	. "github.com/dogmatiq/cosyne"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("type Once", func() {
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+		once   *Once
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 50*time.Millisecond)
+		once = &Once{}
+	})
+
+	AfterEach(func() {
+		cancel()
+	})
+
+	Describe("func Do()", func() {
+		It("does not call the function again after success", func() {
+			called := false
+			err := once.Do(ctx, func(ctx context.Context) error {
+				called = true
+				return nil
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(called).To(BeTrue())
+
+			err = once.Do(ctx, func(ctx context.Context) error {
+				Fail("unexpected call")
+				return nil
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("calls the function again after an error returns", func() {
+			err := once.Do(ctx, func(ctx context.Context) error {
+				return errors.New("<error>")
+			})
+			Expect(err).To(MatchError("<error>"))
+
+			called := false
+			err = once.Do(ctx, func(ctx context.Context) error {
+				called = true
+				return nil
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(called).To(BeTrue())
+		})
+
+		It("blocks conccurent calls to Do()", func() {
+			otherCtx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			barrier := make(chan struct{})
+			go once.Do(otherCtx, func(ctx context.Context) error {
+				close(barrier)
+				<-ctx.Done()
+				return nil
+			})
+
+			<-barrier
+			err := once.Do(ctx, func(context.Context) error {
+				Fail("unexpected call")
+				return nil
+			})
+			Expect(err).To(Equal(context.DeadlineExceeded))
+		})
+	})
+})


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR adds a `Once` type. It is a context-aware and "failable" version of Go's built-in `sync.Once` type.

#### Why make this change?

I have encountered the scenario many times where I want to perform one-time initialization with deadline imposed.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

None
