### PR TITLE
Add "fast path" when RWMutex is already unlocked.

### DIFF
--- a/rwmutex.go
+++ b/rwmutex.go
@@ -71,11 +71,11 @@ func (m *RWMutex) Unlock() {
 //
 // It blocks until the mutex is acquired, or ctx is canceled.
 func (m *RWMutex) RLock(ctx context.Context) error {
-	for {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
 
+	for {
 		m.m.Lock()
 
 		// If there are already other readers, just add ourselves to the reader


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR adds a "fast path" to `RWMutex` when a goroutine is waiting for the mutex to be unlocked (either because `Lock()` is blocking, or `RLock()` is waiting to convert from write-lock to read-lock.

The change checks `m.readers` to avoid `select`'ing the `unlocked` channel when reading will not block.

Use of the "unlocked" and "retry" channels has been abstracted into methods, as the number of places that they are used is growing.

#### Why make this change?

In preparation for `Try[R]Lock()` methods.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

#1 
