### PR TITLE
Add `RWMutex.Try[R]Lock()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 ### Added
 
 - Add `Once`, a context-aware and "failable" variant of `sync.Once`
+- Add `RWMutex.TryLock()` and `TryRLock()`
 
 ## [0.1.0] - 2020-05-20
 


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR adds the `TryLock()` and `TryRLock()` methods to `RWMutex`.

#### Why make this change?

Largely for feature symmetry with `Mutex`.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

Fixes #1 
